### PR TITLE
Replace York resources URL to reflect Wiki changes

### DIFF
--- a/_resources/york.md
+++ b/_resources/york.md
@@ -3,7 +3,7 @@ title: Resources at the University of York
 ---
 
 - [Research Computing Training and Support at the University of
-  York](https://wiki.york.ac.uk/display/RCTS/Research+Computing+Training+and+Support)
+  York](https://wiki.york.ac.uk/x/_IYKDQ)
     - Training courses available at York
 - [York Filestore](https://www.york.ac.uk/it-services/filestore/)
     - Get free storage space


### PR DESCRIPTION
Wiki pages have moved around - replaced the training link with the 'magic' link, which should prevent it from ever being wrong...